### PR TITLE
Modify HAProxy defaults to match with vagrant cluster

### DIFF
--- a/playbooks/roles/haproxy/defaults/main.yml
+++ b/playbooks/roles/haproxy/defaults/main.yml
@@ -49,11 +49,30 @@ haproxy_default_config: |
 # desired applications
 haproxy_applications:
   - |
-    listen rabbitmq 127.0.0.1:5672
+    listen rabbitmq 127.0.0.1:35672
     mode    tcp
     balance roundrobin
     option  tcplog
     option  tcpka
-    server  rabbit01 172.23.128.10:5672 check inter 5000 rise 2 fall 3
-    server  rabbit02 172.23.129.10:5672 backup check inter 5000 rise 2 fall 3
-    server  rabbit03 172.23.130.10:5672 backup check inter 5000 rise 2 fall 3
+    server  rabbit01 192.168.33.100:5672 check inter 5000 rise 2 fall 3
+    server  rabbit02 192.168.33.110:5672 check inter 5000 rise 2 fall 3
+    server  rabbit03 192.168.33.120:5672 check inter 5000 rise 2 fall 3
+
+    listen mariadb 127.0.0.1:13306
+    mode    tcp
+    balance roundrobin
+    option  tcplog
+    option  tcpka
+    option mysql-check
+    server  galera1 192.168.33.100:3306 check weight 1
+    server  galera2 192.168.33.110:3306 check weight 1
+    server  galera3 192.168.33.120:3306 check weight 1
+
+    listen elasticsearch 127.0.0.1:19200
+    mode    tcp
+    balance roundrobin
+    option  tcplog
+    option  tcpka
+    server  galera1 192.168.33.100:9200 check weight 1
+    server  galera2 192.168.33.110:9200 check weight 1
+    server  galera3 192.168.33.120:9200 check weight 1

--- a/playbooks/roles/haproxy/meta/main.yml
+++ b/playbooks/roles/haproxy/meta/main.yml
@@ -18,3 +18,6 @@
 #   my_role_var0: "foo"
 #   my_role_var1: "bar"
 # }
+
+dependencies:
+  - common

--- a/playbooks/roles/haproxy/templates/haproxy.cfg.j2
+++ b/playbooks/roles/haproxy/templates/haproxy.cfg.j2
@@ -1,8 +1,8 @@
 # this config needs haproxy-1.1.28 or haproxy-1.2.1
 
 global
-	log 127.0.0.1	local0
-	log 127.0.0.1	local1 notice
+	log /dev/log	local0 info
+	log /dev/log	local0 notice
 	#log loghost	local0 info
 	maxconn 4096
 	#chroot /usr/share/haproxy


### PR DESCRIPTION
- Also adds MariaDB and elasticsearch to default config
- Remove comments from vagrant-cluster playbook
- Add back verbosity to cluster play
- Make the serial play serial

(cherry picked from commit 453412545a9130397f52d8e30bbeb6dbf7d9811c)

Conflicts:
	playbooks/vagrant-cluster.yml
	vagrant/base/cluster/Vagrantfile