### PR TITLE
Added in missing python-saml dependencies

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -569,6 +569,9 @@ edxapp_debian_pkgs:
   # Needed by the CMS to manipulate images.
   - libjpeg8-dev
   - libpng12-dev
+  # python-saml dependencies: (required for Shibboleth in third_party_auth)
+  - libxmlsec1-dev
+  - swig
 
 # Ruby Specific Vars
 edxapp_ruby_version: "1.9.3-p374"


### PR DESCRIPTION
(cherry-picked from e103e47e1b204f65c67572cf62ec0f0ed5b0951e)

To fix build failure on edx-ci:
```
Collecting dm.xmlsec.binding==1.3.2 (from python-saml==2.1.3->-r /edx/app/edxapp/edx-platform/requirements/edx/base.txt (line 73))
  Downloading http://localhost:4040/root/pypi/+f/3c3/bfd3569b139c7/dm.xmlsec.binding-1.3.2.tar.gz (119kB)
    Error: cannot get XMLSec1 pre-processor and compiler flags; do you have the `libxmlsec1` development package installed?
    Complete output from command python setup.py egg_info:
    Error: cannot get XMLSec1 pre-processor and compiler flags; do you have the `libxmlsec1` development package installed?
```

@carsongee