### PR TITLE
Removed post.txt from the list of files that will have its github url…

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -262,9 +262,8 @@ edxapp_chksum_req_files:
   - "{{ sandbox_base_requirements }}"
 
 # all edxapp requirements files
-edxapp_all_req_files:
+edxapp_requirements_with_github_urls:
   - "{{ pre_requirements_file }}"
-  - "{{ post_requirements_file }}"
   - "{{ base_requirements_file }}"
   - "{{ paver_requirements_file }}"
   - "{{ github_requirements_file }}"

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -264,6 +264,7 @@ edxapp_chksum_req_files:
 # all edxapp requirements files
 edxapp_requirements_with_github_urls:
   - "{{ pre_requirements_file }}"
+  - "{{ post_requirements_file }}"
   - "{{ base_requirements_file }}"
   - "{{ paver_requirements_file }}"
   - "{{ github_requirements_file }}"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -56,12 +56,19 @@
   register: inst
   sudo_user: "{{ edxapp_user }}"
 
+- name: Stat each requirements file to ensure it exists
+  stat: path="{{ item }}"
+  with_items: "{{ edxapp_requirements_with_github_urls }}"
+  register: requirement_file_stats
+
 # Substitute github mirror in all requirements files
 # This is run on every single deploy
 - name: Updating requirement files for git mirror
   command: |
-    /bin/sed -i -e 's/github\.com/{{ COMMON_GIT_MIRROR }}/g' {{ " ".join(edxapp_requirements_with_github_urls) }}
+    /bin/sed -i -e 's/github\.com/{{ COMMON_GIT_MIRROR }}/g' {{ item.item }}
   sudo_user: "{{ edxapp_user }}"
+  when: item.stat.exists
+  with_items: "{{ requirement_file_stats.results }}"
 
 # Ruby plays that need to be run after platform updates.
 - name: gem install bundler

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -60,7 +60,7 @@
 # This is run on every single deploy
 - name: Updating requirement files for git mirror
   command: |
-    /bin/sed -i -e 's/github\.com/{{ COMMON_GIT_MIRROR }}/g' {{ " ".join(edxapp_all_req_files) }}
+    /bin/sed -i -e 's/github\.com/{{ COMMON_GIT_MIRROR }}/g' {{ " ".join(edxapp_requirements_with_github_urls) }}
   sudo_user: "{{ edxapp_user }}"
 
 # Ruby plays that need to be run after platform updates.


### PR DESCRIPTION
…s replaced with git mirror urls.

(cherry picked from commit 09807f8ee9fc65c6e727cce66803562bd442f8b4)

@carsongee As you mentioned, just taking the edX config change as-is might not be the right way to go for backwards compatibility purposes, but I figure I'd cherry-pick it and discuss a fix here.