### PR TITLE
Add file creation checks when inserting haproxy users into mariadb

### DIFF
--- a/playbooks/roles/mariadb/tasks/cluster.yml
+++ b/playbooks/roles/mariadb/tasks/cluster.yml
@@ -55,4 +55,5 @@
 - name: create haproxy monitor user
   command: >
     mysql -e "INSERT INTO mysql.user (Host,User) values ('{{ item }}','{{ MARIADB_HAPROXY_USER }}'); FLUSH PRIVILEGES;"
+    creates=/etc/ansible_{{ item }}_haproxy_added
   with_items: MARIADB_HAPROXY_HOSTS


### PR DESCRIPTION
This just allows for running the role multiple times.. It's not really perfect, as it should really be checking if the record is already inserted, or maybe parse the failure to see if the error contains "duplicate entry" or something.

This is just a quick fix, as I had to run `mariadb.yml` it multiple times due to it failing on the SMTP role. @carsongee 