### PR TITLE
Cherry pick/bdero/install rabbit from deb

### DIFF
--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -28,9 +28,15 @@ rabbitmq_refresh: false
 
 rabbitmq_apt_key: "http://www.rabbitmq.com/rabbitmq-signing-key-public.asc"
 rabbitmq_repository: "deb http://www.rabbitmq.com/debian/ testing main"
+# We mirror the deb package for rabbitmq-server because
+# nodes need to be running the same version
+rabbitmq_pkg_url: "http://files.edx.org/rabbitmq_packages/rabbitmq-server_3.2.3-1_all.deb"
 rabbitmq_pkg: "rabbitmq-server"
 rabbitmq_debian_pkgs:
   - python-software-properties
+  # for installing the deb package with
+  # dependencies
+  - gdebi
 
 rabbitmq_config_dir: "/etc/rabbitmq"
 rabbitmq_cookie_dir: "/var/lib/rabbitmq"

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: fetch the rabbitmq server deb
   get_url: >
-    url=http://{{ rabbitmq_pkg_url }}
+    url={{ rabbitmq_pkg_url }}
     dest=/var/tmp/{{ rabbitmq_pkg_url|basename }}
 
 - name: install rabbit package using gdebi

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -10,10 +10,17 @@
   apt: pkg={{",".join(rabbitmq_debian_pkgs)}} state=present
 
 - name: add rabbit repository
-  apt_repository_1.8: repo="{{rabbitmq_repository}}" state=present validate_certs=no
+  apt_repository_1.8: repo="{{rabbitmq_repository}}" state=present update_cache=yes validate_certs=no
 
-- name: install rabbitmq
-  apt: pkg={{rabbitmq_pkg}} state=present update_cache=yes
+- name: fetch the rabbitmq server deb
+  get_url: >
+    url=http://{{ rabbitmq_pkg_url }}
+    dest=/var/tmp/{{ rabbitmq_pkg_url|basename }}
+
+- name: install rabbit package using gdebi
+  shell: >
+    gdebi --n {{ rabbitmq_pkg_url|basename }}
+    chdir=/var/tmp
 
 - name: stop rabbit cluster
   service: name=rabbitmq-server state=stopped


### PR DESCRIPTION
Ran a sandbox provision and `rabbitmq-server` couldn't be installed due to a dependency issue:
```
failed: [sandbox0rpc.d] => {"failed": true, "item": ""}
stderr: E: Unable to correct problems, you have held broken packages.

stdout: Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 rabbitmq-server : Depends: erlang-nox (>= 1:16.b.3) but it is not going to be installed or
                            esl-erlang but it is not installable

msg: 'apt-get install 'rabbitmq-server' ' failed: E: Unable to correct problems, you have held broken packages.
```

So I looked at how edX is installing it in their repo nowadays, did a git blame, and came across this PR: https://github.com/edx/configuration/pull/989

Problem solved.