### PR TITLE
Django 1.8 migration changes for xqueue

### DIFF
--- a/playbooks/roles/xqueue/tasks/deploy.yml
+++ b/playbooks/roles/xqueue/tasks/deploy.yml
@@ -62,9 +62,9 @@
 
 # If there is a common user for migrations run migrations using his username
 # and credentials. If not we use the xqueue mysql user
-- name: syncdb and migrate
+- name: migrate
   shell: >
-    SERVICE_VARIANT=xqueue {{ xqueue_venv_bin }}/django-admin.py syncdb --migrate --noinput --settings=xqueue.aws_migrate --pythonpath={{ xqueue_code_dir }}
+    SERVICE_VARIANT=xqueue {{ xqueue_venv_bin }}/django-admin.py migrate --noinput --settings=xqueue.aws_migrate --pythonpath={{ xqueue_code_dir }}
   sudo_user: "{{ xqueue_user }}"
   environment:
     DB_MIGRATION_USER: "{{ COMMON_MYSQL_MIGRATE_USER }}"

--- a/playbooks/roles/xqueue/tasks/deploy.yml
+++ b/playbooks/roles/xqueue/tasks/deploy.yml
@@ -75,7 +75,7 @@
 
 - name: syncdb and migrate
   shell: >
-    SERVICE_VARIANT=xqueue {{ xqueue_venv_bin }}/django-admin.py syncdb --migrate --noinput --settings=xqueue.aws_settings --pythonpath={{ xqueue_code_dir }}
+    SERVICE_VARIANT=xqueue {{ xqueue_venv_bin }}/django-admin.py migrate --noinput --settings=xqueue.aws_settings --pythonpath={{ xqueue_code_dir }}
   sudo_user: "{{ xqueue_user }}"
   when: migrate_db is defined and migrate_db|lower == "yes" and not COMMON_MYSQL_MIGRATE_PASS
   notify:


### PR DESCRIPTION
Now that XQueue's repo is running on 1.8, we need to use the new syntax
https://docs.djangoproject.com/en/1.8/ref/django-admin/#syncdb

(cherry picked from commit 9bd33827d7675fb877d32e77ce57612ce9a7d2b1)