### PR TITLE
Cherry pick/bdero/forums fixes 2669

### DIFF
--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -52,7 +52,7 @@ forum_environment:
   LISTEN_PORT: "{{ FORUM_LISTEN_PORT }}"
 
 forum_user: "forum"
-forum_ruby_version: "1.9.3-p448"
+forum_ruby_version: "1.9.3-p551"
 forum_source_repo: "https://github.com/edx/cs_comments_service.git"
 forum_version: "master"
 

--- a/playbooks/roles/rbenv/defaults/main.yml
+++ b/playbooks/roles/rbenv/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 
-rbenv_version: 'v0.4.0'
-rbenv_bundler_version: '1.3.2'
-rbenv_rake_version: '10.0.3'
+rbenv_version: 'v1.0.0'
+rbenv_bundler_version: '1.11.2'
+rbenv_rake_version: '10.4.2'
 rbenv_root: "{{ rbenv_dir }}/.rbenv"
 rbenv_gem_root: "{{ rbenv_dir }}/.gem"
 rbenv_gem_bin: "{{ rbenv_gem_root }}/bin"

--- a/playbooks/roles/rbenv/tasks/main.yml
+++ b/playbooks/roles/rbenv/tasks/main.yml
@@ -121,8 +121,23 @@
   shell: "gem install rake -v {{ rbenv_rake_version }}"
   sudo_user: "{{ rbenv_user }}"
   environment: "{{ rbenv_environment }}"
+  when: jenkins_worker is not defined or not jenkins_worker
+  tags:
+    - install
+    - install:base
 
+- name: update rubygems
+  shell: "gem install rubygems-update && update_rubygems"
+  sudo_user: "{{ rbenv_user }}"
+  environment: "{{ rbenv_environment }}"
+  tags:
+    - install
+    - install:base
+    
 - name: rehash
   shell: "rbenv rehash"
   sudo_user: "{{ rbenv_user }}"
   environment: "{{ rbenv_environment }}"
+  tags:
+    - install
+    - install:base


### PR DESCRIPTION
These commits (from https://github.com/edx/configuration/pull/2669) improve the way forums are installed, and corrects the version of ruby to match the latest forums version.


Supervisor forum error log:
`rbenv: version `1.9.3-p551' is not installed`


Current ruby env:
`ruby 1.9.3p448 (2013-06-27 revision 41675) [x86_64-linux]`


Version `1.9.3-p551` is in "cs-comment-service/.ruby-version".