### PR TITLE
Ignore errors when reloading nginx

### DIFF
--- a/playbooks/roles/nginx/handlers/main.yml
+++ b/playbooks/roles/nginx/handlers/main.yml
@@ -4,3 +4,4 @@
 
 - name: reload nginx
   service: name=nginx state=reloaded
+  ignore_errors: yes


### PR DESCRIPTION
The reasoning here is similar to https://github.mit.edu/mitx-devops/mitx-ansible/pull/142. This handler always fails on Ansible 1.8. I preferred ignoring the error here over removing the handler triggers from every task "requiring it". The Nginx restart handler is _always_ triggered on deployments anyways, rendering this task pretty much redundant.

@blarghmatey @pdpinch 