### PR TITLE
Remove server_utils from common role

### DIFF
--- a/playbooks/roles/common/meta/main.yml
+++ b/playbooks/roles/common/meta/main.yml
@@ -1,7 +1,6 @@
 ---
 dependencies:
   - common_vars
-  - server_utils
   - role: user
     user_info: "{{ COMMON_USER_INFO }}"
   - role: security


### PR DESCRIPTION
Remove server_utils from common role as it installs admin tools on the host which we don't have a use for given our current setup. In addition, don't think it's a good idea from a security perspective to have netcat already installed on any host.
As far as I can tell, none of the tools installed by server_utils are required for the successful completion of the ansible run. 
In addition, I ran into a problem on a standalone host when trying to execute the edxapp_migrate playbook since it has `gather_facts = False` and when it tries to execute the server_utils role, it fails with:
```"The conditional check 'ansible_distribution == 'Ubuntu'' failed. The error was: error while evaluating conditional (ansible_distribution == 'Ubuntu')```
since it can't verify that it's running on a Ubuntu host given that it was told not to gather facts.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?