### PR TITLE
Removed when statement for CREATE_SERVICE_WORKER_USERS

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -421,7 +421,6 @@
 - name: build service worker users list
   set_fact:
     service_worker_users: "{{ [SERVICE_WORKER_USERS] }}"
-  when: CREATE_SERVICE_WORKER_USERS
   tags:
     - manage
     - manage:db


### PR DESCRIPTION
Removed when statement for CREATE_SERVICE_WORKER_USERS for `build service worker users list` as it was failing to render service_worker_users in the line above it with the following message:
`service_worker_users is undefined`

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?