### PR TITLE
Added path to venvs python as it does not appear to be set in edxapp_migrate

### DIFF
--- a/playbooks/edx-east/edxapp_migrate.yml
+++ b/playbooks/edx-east/edxapp_migrate.yml
@@ -4,6 +4,7 @@
   gather_facts: True
   vars:
     db_dry_run: "--list"
+    edxapp_code_dir: "/edx/app/edxapp/venvs/edxapp/bin/"
   roles:
     - edxapp
   tasks:


### PR DESCRIPTION
Added path to venvs python as it does not appear to be set in edxapp_migrate and was failing to find safe_lxml which is already installed in the venvs which drives us to think that it's not running in the correct environment.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?