### PR TITLE
Added path to venvs python as it does not appear to be set in edxapp_migrate

### DIFF
--- a/playbooks/edx-east/edxapp_migrate.yml
+++ b/playbooks/edx-east/edxapp_migrate.yml
@@ -8,7 +8,7 @@
     - edxapp
   tasks:
     - name: migrate lms
-      shell: "python manage.py lms migrate --database {{ item }} --noinput {{ db_dry_run }} --settings=aws"
+      shell: "/edx/app/edxapp/venvs/edxapp/bin/python manage.py lms migrate --database {{ item }} --noinput {{ db_dry_run }} --settings=aws"
       args:
         chdir: "{{ edxapp_code_dir }}"
       environment:
@@ -21,7 +21,7 @@
       tags:
         - always
     - name: migrate cms
-      shell: "python manage.py cms migrate --database {{ item }} --noinput {{ db_dry_run }} --settings=aws"
+      shell: "/edx/app/edxapp/venvs/edxapp/bin/python manage.py cms migrate --database {{ item }} --noinput {{ db_dry_run }} --settings=aws"
       args:
         chdir: "{{ edxapp_code_dir }}"
       environment:


### PR DESCRIPTION
Added path to venvs python as it does not appear to be set in edxapp_migrate and was failing to find safe_lxml which is already installed in the venvs which drives us to think that it's not running in the correct environment.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?