### PR TITLE
Added edxapp as the user to run migrations

### DIFF
--- a/playbooks/edx-east/edxapp_migrate.yml
+++ b/playbooks/edx-east/edxapp_migrate.yml
@@ -1,6 +1,7 @@
 - name: Run edxapp migrations
   hosts: all
-  become: False
+  become: True
+  become_user: edxapp
   gather_facts: True
   vars:
     db_dry_run: "--list"


### PR DESCRIPTION
Added edxapp as the user to run migrations. Currently migrations don't appear be to executing through the ansible run and current edxapp_migrate role has set become False.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?