### PR TITLE
Replaced Stanford theme with mitx-theme

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1256,8 +1256,8 @@ worker_core_mult:
 #
 # TODO: change variables to ALL-CAPS, since they are meant to be externally overridden
 edxapp_theme_name: ""
-edxapp_theme_source_repo: 'https://{{ COMMON_GIT_MIRROR }}/Stanford-Online/edx-theme.git'
-edxapp_theme_version: 'master'
+edxapp_theme_source_repo: 'https://github.com/mitodl/mitx-theme.git'
+edxapp_theme_version: 'ficus'
 
 # make this the public URL instead of writable
 edx_platform_repo: "https://{{ COMMON_GIT_MIRROR }}/edx/edx-platform.git"


### PR DESCRIPTION
Replaced Stanford theme with mitx-theme as it was causing a problem with a salt state run, where the theme was pulled, but didn't apply and we had to delete and run another git pull for it to work.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?