### PR TITLE
Remove default datadog-uninstall

### DIFF
--- a/playbooks/aide.yml
+++ b/playbooks/aide.yml
@@ -12,5 +12,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG

--- a/playbooks/analyticsapi.yml
+++ b/playbooks/analyticsapi.yml
@@ -18,5 +18,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG

--- a/playbooks/antivirus.yml
+++ b/playbooks/antivirus.yml
@@ -9,6 +9,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/automated.yml
+++ b/playbooks/automated.yml
@@ -9,6 +9,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/certs.yml
+++ b/playbooks/certs.yml
@@ -12,6 +12,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -11,6 +11,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/common_edx_base.yml
+++ b/playbooks/common_edx_base.yml
@@ -17,6 +17,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/commoncluster.yml
+++ b/playbooks/commoncluster.yml
@@ -31,8 +31,6 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
     - role: nginx
       nginx_sites:
       - xqueue

--- a/playbooks/credentials.yml
+++ b/playbooks/credentials.yml
@@ -18,5 +18,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG

--- a/playbooks/demo.yml
+++ b/playbooks/demo.yml
@@ -11,5 +11,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG

--- a/playbooks/discovery.yml
+++ b/playbooks/discovery.yml
@@ -18,6 +18,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/ecommerce.yml
+++ b/playbooks/ecommerce.yml
@@ -18,6 +18,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/ecomworker.yml
+++ b/playbooks/ecomworker.yml
@@ -14,6 +14,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/edx-stateless.yml
+++ b/playbooks/edx-stateless.yml
@@ -86,6 +86,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/edx_continuous_integration.yml
+++ b/playbooks/edx_continuous_integration.yml
@@ -43,6 +43,4 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
     - flower

--- a/playbooks/edxapp.yml
+++ b/playbooks/edxapp.yml
@@ -30,6 +30,3 @@
      when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
    - role: minos
      when: COMMON_ENABLE_MINOS
-   - role: datadog-uninstall
-     when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/forum.yml
+++ b/playbooks/forum.yml
@@ -18,6 +18,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/insights.yml
+++ b/playbooks/insights.yml
@@ -18,6 +18,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/jenkins_build.yml
+++ b/playbooks/jenkins_build.yml
@@ -20,8 +20,6 @@
     - aws
     - role: datadog
       when: COMMON_ENABLE_DATADOG
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
     - jenkins_build
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE

--- a/playbooks/jenkins_testeng_master.yml
+++ b/playbooks/jenkins_testeng_master.yml
@@ -52,8 +52,6 @@
     - aws
     - role: datadog
       when: COMMON_ENABLE_DATADOG
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
     - jenkins_master
 
     # run just the splunkforwarder role by using '--tags "splunkonly"'

--- a/playbooks/journals.yml
+++ b/playbooks/journals.yml
@@ -20,5 +20,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG

--- a/playbooks/mongo.yml
+++ b/playbooks/mongo.yml
@@ -11,6 +11,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/mongo_3_0.yml
+++ b/playbooks/mongo_3_0.yml
@@ -25,6 +25,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/mongo_3_2.yml
+++ b/playbooks/mongo_3_2.yml
@@ -30,6 +30,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/mongo_3_4.yml
+++ b/playbooks/mongo_3_4.yml
@@ -30,5 +30,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG

--- a/playbooks/mongo_mms.yml
+++ b/playbooks/mongo_mms.yml
@@ -10,5 +10,3 @@
     - mongo_mms
     - role: datadog
       when: COMMON_ENABLE_DATADOG
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG

--- a/playbooks/notes.yml
+++ b/playbooks/notes.yml
@@ -17,6 +17,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -90,5 +90,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: postfix_queue
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG

--- a/playbooks/redirector.yml
+++ b/playbooks/redirector.yml
@@ -19,6 +19,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/redis.yml
+++ b/playbooks/redis.yml
@@ -11,6 +11,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/snort.yml
+++ b/playbooks/snort.yml
@@ -12,6 +12,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/testcourses.yml
+++ b/playbooks/testcourses.yml
@@ -11,6 +11,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/tools_jenkins.yml
+++ b/playbooks/tools_jenkins.yml
@@ -22,8 +22,6 @@
     # so this needs to run early.
     - role: datadog
       when: COMMON_ENABLE_DATADOG
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
     - tools_jenkins
     # This requires an override of the following form:
     # SPLUNKFORWARDER_LOG_ITEMS:

--- a/playbooks/vpc_admin.yml
+++ b/playbooks/vpc_admin.yml
@@ -15,5 +15,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG

--- a/playbooks/whitelabel.yml
+++ b/playbooks/whitelabel.yml
@@ -24,6 +24,4 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
     - whitelabel

--- a/playbooks/worker.yml
+++ b/playbooks/worker.yml
@@ -12,7 +12,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: minos
       when: COMMON_ENABLE_MINOS
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-
-

--- a/playbooks/xqueue.yml
+++ b/playbooks/xqueue.yml
@@ -15,6 +15,3 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/xqwatcher.yml
+++ b/playbooks/xqwatcher.yml
@@ -16,6 +16,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-

--- a/playbooks/xserver.yml
+++ b/playbooks/xserver.yml
@@ -15,6 +15,3 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
-    - role: datadog-uninstall
-      when: not COMMON_ENABLE_DATADOG
-


### PR DESCRIPTION
When `COMMON_ENABLE_DATADOG` is not defined, the datadog-uninstall role runs causing the removal of the apt key and eventually leading to the failure of the saltstack highstate with the following error: 

```W: Failed to fetch https://apt.datadoghq.com/dists/stable/Release.gpg  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 4B4593018387EEAF```

Additionally, I don't see the need of running a datadog-uninstall by default when an install hasn't even been called.
