### PR TITLE
Added force clone flag to overwrite local changes

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -41,6 +41,7 @@
     repo: "{{ edx_platform_repo }}"
     version: "{{ edx_platform_version }}"
     accept_hostkey: yes
+    force: yes
   become_user: "{{ edxapp_user }}"
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"


### PR DESCRIPTION
Configuration Pull Request
---

Currently when executing out `build_ami` state, if it fails for whatever reason and we have to run it again, it is failing on cloning the edx-platform repo as part of the build_ami state is making some changes to certain files. The [added flag](https://docs.ansible.com/ansible/latest/modules/git_module.html) would simply overwrite any changes in edx-platform.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?