### PR TITLE
Changed sandbox to python2.7

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1062,7 +1062,7 @@ EDXAPP_WORKER_DEFAULT_STOPWAITSECS: 432000
 # setup for python codejail
 edxapp_sandbox_venv_dir:  '{{ edxapp_venvs_dir }}/edxapp-sandbox'
 edxapp_sandbox_user: 'sandbox'  # I think something about the codejail requires hardcoding this to sandbox:sandbox
-edxapp_sandbox_python_version: 'python3.5' # change to 'python2.7' if you want to go back to the old setting.
+edxapp_sandbox_python_version: 'python2.7' # change to 'python2.7' if you want to go back to the old setting.
 
 # apparmor command
 edxapp_aa_command: "{% if EDXAPP_SANDBOX_ENFORCE %}aa-enforce{% else %}aa-complain{% endif %}"


### PR DESCRIPTION
Temporarily changing the sandbox to using python2.7 to deploy new production instances as some courses have yet to be tested using python3.