### PR TITLE
Quote the referer field in the Nginx access log format

### DIFF
--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -47,7 +47,7 @@ http {
 
         log_format app_metrics 'time=$time_iso8601 client=$remote_addr method=$request_method request="$request" '
                                'request_length=$request_length status=$status bytes_sent=$bytes_sent body_bytes_sent=$body_bytes_sent '
-                               'referer=$http_referer user_agent="$http_user_agent" upstream_addr=$upstream_addr upstream_status=$upstream_status '
+                               'referer="$http_referer" user_agent="$http_user_agent" upstream_addr=$upstream_addr upstream_status=$upstream_status '
                                'request_time=$request_time request_id=$request_id upstream_response_time=$upstream_response_time '
                                'upstream_connect_time=$upstream_connect_time upstream_header_time=$upstream_header_time';
 


### PR DESCRIPTION
Quote the referer field to avoid log parsing issues when there are special characters in the URL in this field.

At least one logging agent, Vector, fails to parse this correctly with its standard "logfmt_parser" when there are certain characters present. The "request" field is already quoted, and referer should get the same treatment.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
